### PR TITLE
Add language detection with user prompt

### DIFF
--- a/Changelog.org
+++ b/Changelog.org
@@ -5,6 +5,12 @@ upcoming changes.
 In case a update to the org sources is needed, I'll add a changelog
 entry with updating instructions.
 
+** 0.6.4
+
+*** Added
+
+- Automatically detect language codes and prompt the user when detection is ambiguous.
+
 ** 0.6.3
 
 *** Fixed

--- a/org-fc-core.el
+++ b/org-fc-core.el
@@ -114,6 +114,11 @@ Used to generate absolute paths to the awk scripts.")
   :type '(list string)
   :group 'org-fc)
 
+(defcustom org-fc-language-codes '("en" "de" "fr" "es" "it" "zh" "ja")
+  "List of language codes used when prompting for a language."
+  :type '(repeat string)
+  :group 'org-fc)
+
 ;;;; Spacing Parameters
 
 (defcustom org-fc-algorithm 'sm2-v1
@@ -217,6 +222,25 @@ indenting the current heading."
       (org-indent-add-properties
        (org-element-property :begin el)
        (org-element-property :end el)))))
+
+(defun org-fc--guess-language-code (text)
+  "Guess the ISO 639-1 language code for TEXT.
+Return nil when the language cannot be determined with confidence."
+  (cond
+   ;; Presence of Hiragana or Katakana implies Japanese
+   ((string-match-p "[\u3040-\u309f\u30a0-\u30ff]" text) "ja")
+   ;; CJK unified ideographs alone are ambiguous (could be Chinese or Japanese)
+   ((string-match-p "[\u4e00-\u9fff]" text) nil)
+   ;; A simple heuristic for English text using Latin letters
+   ((string-match-p "[A-Za-z]" text) "en")
+   (t nil)))
+
+(defun org-fc-detect-language-code (text)
+  "Determine language code for TEXT.
+Try to guess the language automatically; if guessing fails, prompt
+the user to choose one from `org-fc-language-codes'."
+  (or (org-fc--guess-language-code text)
+      (completing-read "Language code: " org-fc-language-codes nil t)))
 
 (defmacro org-fc-with-point-at-entry (&rest body)
   "Execute BODY with point at the card heading.

--- a/tests/org-fc-language-test.el
+++ b/tests/org-fc-language-test.el
@@ -1,0 +1,11 @@
+(require 'ert)
+(require 'org-fc-core)
+
+(ert-deftest org-fc-language-guess-japanese ()
+  (should (equal "ja" (org-fc--guess-language-code "かなカナ"))))
+
+(ert-deftest org-fc-language-guess-english ()
+  (should (equal "en" (org-fc--guess-language-code "hello"))))
+
+(ert-deftest org-fc-language-guess-ambiguous ()
+  (should-not (org-fc--guess-language-code "漢字")))


### PR DESCRIPTION
## Summary
- add customizable list of language codes
- guess language codes from text and prompt user when ambiguous
- test language guessing and document the new feature

## Testing
- `./makem.sh lint` *(fails: emacs not found)*
- `./makem.sh test` *(fails: emacs not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d07dd5c08333a823333c72a4d2f5