### PR TITLE
Add Forvo audio download

### DIFF
--- a/Changelog.org
+++ b/Changelog.org
@@ -5,6 +5,13 @@ upcoming changes.
 In case a update to the org sources is needed, I'll add a changelog
 entry with updating instructions.
 
+** Unreleased
+
+*** Added
+
+- ~org-fc-audio-set-forvo~ downloads pronunciations from Forvo and
+  stores them on the current headline.
+
 ** 0.6.3
 
 *** Fixed

--- a/docs/extensions.org
+++ b/docs/extensions.org
@@ -27,6 +27,13 @@ will prompt the user for a file and a position on of the current card.
 - ~org-fc-audio-set-before-setup~
 - ~org-fc-audio-set-after-setup~
 - ~org-fc-audio-set-after-flip~
+- ~org-fc-audio-set-forvo~
+
+~org-fc-audio-set-forvo~ downloads the most popular pronunciation for
+the current heading from Forvo and stores it in the directory specified
+by ~org-fc-audio-forvo-directory~.  The API key is read from
+~org-fc-audio-forvo-api-key~ and the resulting file is linked on the
+headline with a property like =:FC_AUDIO_EN:=.
 
 For most card types, =AFTER_SETUP= and =AFTER_FLIP= are sufficient.
 The only exception are text-input cards as those prompt the user for an answer


### PR DESCRIPTION
## Summary
- add Forvo-based audio download with `org-fc-audio-set-forvo`
- allow configuring API key, download directory, proxy, and language options
- document Forvo support

## Testing
- `./makem.sh lint` *(fails: emacs: command not found)*
- `./makem.sh test` *(fails: emacs: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d472ba5483338ce96845e1690703